### PR TITLE
Docker Composeを使った場合の設定改善案

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
       - "53306:3306"
     volumes:
       - ./docker/db/my.cnf:/etc/mysql/conf.d/my.cnf
-      - ./docker/db/mysql_data:/var/lib/mysql
+      - mysql_data:/var/lib/mysql
+      - ./docker/db/init:/docker-entrypoint-initdb.d
     env_file:
       - ./docker/db/db-variables.env
+volumes:
+  mysql_data:

--- a/docker/db/init/init.sql
+++ b/docker/db/init/init.sql
@@ -1,0 +1,10 @@
+CREATE TABLE reviews (
+  id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  title VARCHAR(255),
+  author VARCHAR(100),
+  status VARCHAR(5),
+  time DATE,
+  evaluation INTEGER(1),
+  impressions VARCHAR(1000),
+  creation_date_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+) DEFAULT CHARACTER SET = utf8mb4;

--- a/docker/db/mysql_data/.gitignore
+++ b/docker/db/mysql_data/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Docker Compose環境を拝見させていただき、こうしたら良いのでは？という点についてプルリクエストを上げました。

* MySQLのデータベースのデータファイルは、Gitで管理してしまうと各個人の環境に影響してしまうため、Git管理対象から外すのが良いです。（ **volumes** という設定を利用して、DockerにMySQLのデータファイルを管理してもらいます。 ）
* MySQLのDockerイメージを利用した場合、初回起動時に `/docker-entrypoint-initdb.d` というディレクトリのSQLファイルが自動的に実行される、という仕組みがあります。これを利用してDBテーブルの作成を行うことができます。

